### PR TITLE
Fix: Korrigiert Caching-Mechanismus um sourceLanguage

### DIFF
--- a/convex/cache.ts
+++ b/convex/cache.ts
@@ -7,16 +7,19 @@ import { QueryCtx, MutationCtx } from "./_generated/server";
 export const getTranslationFromCache = internalQuery({
   args: {
     originalTextSHA256: v.string(),
+    sourceLanguage: v.string(), // Added
     targetLanguage: v.string(),
   },
   handler: async (
     ctx: QueryCtx,
-    args: { originalTextSHA256: string; targetLanguage: string }
+    args: { originalTextSHA256: string; sourceLanguage: string; targetLanguage: string } // Updated args type
   ): Promise<Doc<"translationsCache"> | null> => {
     const result = await ctx.db
       .query("translationsCache")
-      .withIndex("by_original_text_sha256_and_target_language", (q) =>
-        q.eq("originalTextSHA256", args.originalTextSHA256).eq("targetLanguage", args.targetLanguage)
+      .withIndex("by_original_text_sha256_and_source_and_target_language", (q) => // Index name updated
+        q.eq("originalTextSHA256", args.originalTextSHA256)
+         .eq("sourceLanguage", args.sourceLanguage) // Added sourceLanguage condition
+         .eq("targetLanguage", args.targetLanguage)
       )
       .unique();
     return result;
@@ -28,6 +31,7 @@ export const storeTranslationInCache = internalMutation({
   args: {
     originalTextSHA256: v.string(),
     originalText: v.string(),
+    sourceLanguage: v.string(), // Added
     targetLanguage: v.string(),
     translatedText: v.string(),
   },
@@ -36,6 +40,7 @@ export const storeTranslationInCache = internalMutation({
     args: {
       originalTextSHA256: string;
       originalText: string;
+      sourceLanguage: string; // Updated args type
       targetLanguage: string;
       translatedText: string;
     }
@@ -43,6 +48,7 @@ export const storeTranslationInCache = internalMutation({
     await ctx.db.insert("translationsCache", {
       originalTextSHA256: args.originalTextSHA256,
       originalText: args.originalText,
+      sourceLanguage: args.sourceLanguage, // Added
       targetLanguage: args.targetLanguage,
       translatedText: args.translatedText,
     });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -6,9 +6,10 @@ const applicationTables = {
   translationsCache: defineTable({
     originalTextSHA256: v.string(),
     originalText: v.string(),
+  sourceLanguage: v.string(), // Added
     targetLanguage: v.string(),
     translatedText: v.string(),
-  }).index("by_original_text_sha256_and_target_language", ["originalTextSHA256", "targetLanguage"]),
+}).index("by_original_text_sha256_and_source_and_target_language", ["originalTextSHA256", "sourceLanguage", "targetLanguage"]), // Index name and fields updated
 
   userGlossaries: defineTable({
     userId: v.id("users"),

--- a/convex/translate.ts
+++ b/convex/translate.ts
@@ -55,13 +55,14 @@ export const translateText = action({
     }
 
     // 2. Check general cache
-    const cacheKeyString = `${textToTranslate.toLowerCase()}|${args.targetLanguage.toLowerCase()}`;
+    const cacheKeyString = `${textToTranslate.toLowerCase()}|${args.sourceLanguage.toLowerCase()}|${args.targetLanguage.toLowerCase()}`;
     const originalTextSHA256 = await sha256(cacheKeyString);
 
     const cached: Doc<"translationsCache"> | null = await ctx.runQuery(
       internal.cache.getTranslationFromCache,
       {
         originalTextSHA256,
+        sourceLanguage: args.sourceLanguage, // Added
         targetLanguage: args.targetLanguage,
       }
     );
@@ -91,6 +92,7 @@ export const translateText = action({
         await ctx.runMutation(internal.cache.storeTranslationInCache, {
           originalTextSHA256,
           originalText: textToTranslate,
+          sourceLanguage: args.sourceLanguage, // Added
           targetLanguage: args.targetLanguage,
           translatedText,
         });


### PR DESCRIPTION
### **User description**
Der Caching-Mechanismus für Übersetzungen berücksichtigte bisher nicht die Ausgangssprache (`sourceLanguage`). Dies konnte dazu führen, dass für denselben Text, der aus unterschiedlichen Ausgangssprachen in dieselbe Zielsprache übersetzt wurde, fälschlicherweise derselbe Cache-Eintrag verwendet wurde.

Diese Änderungen beheben das Problem:
- `convex/schema.ts`: Ich habe die Tabelle `translationsCache` um das Feld `sourceLanguage` erweitert. Der zugehörige Index wurde angepasst, um `sourceLanguage` einzuschließen (`by_original_text_sha256_and_source_and_target_language`).
- `convex/cache.ts`: Ich habe die Funktionen `getTranslationFromCache` und `storeTranslationInCache` aktualisiert, um `sourceLanguage` in ihren Argumenten, Datenbankabfragen und Speicheroperationen zu berücksichtigen.
- `convex/translate.ts`: Ich habe die Generierung des Cache-Schlüssels (`cacheKeyString`) so angepasst, dass sie nun `sourceLanguage` einbezieht. Die Aufrufe der internen Cache-Funktionen übergeben `sourceLanguage` korrekt.

Bestehende Cache-Einträge, die vor dieser Korrektur erstellt wurden, sind weiterhin inkonsistent, werden aber aufgrund der geänderten Abfragelogik nicht mehr fälschlicherweise verwendet. Eine manuelle Bereinigung des alten Caches kann in Betracht gezogen werden.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix translation cache to include `sourceLanguage`
  - Updates cache key and DB queries to use `sourceLanguage`
  - Prevents incorrect cache hits for same text with different source languages

- Update schema and index for `translationsCache` table
  - Adds `sourceLanguage` field and updates index accordingly

- Refactor cache-related functions to handle new argument


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cache.ts</strong><dd><code>Add sourceLanguage to cache logic and DB operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

convex/cache.ts

<li>Adds <code>sourceLanguage</code> to cache query and mutation arguments<br> <li> Updates DB queries and insertions to use <code>sourceLanguage</code><br> <li> Changes index name and usage to include <code>sourceLanguage</code>


</details>


  </td>
  <td><a href="https://github.com/Jokerman890/Polyglote-Translater-Beta-v1.0.0.1/pull/4/files#diff-2e779ae684a556e5d2f731261b37588f3a2914cdc491634dd8e1d0a5cece5d9a">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>translate.ts</strong><dd><code>Include sourceLanguage in cache key and function calls</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

convex/translate.ts

<li>Updates cache key generation to include <code>sourceLanguage</code><br> <li> Passes <code>sourceLanguage</code> to cache query and mutation calls


</details>


  </td>
  <td><a href="https://github.com/Jokerman890/Polyglote-Translater-Beta-v1.0.0.1/pull/4/files#diff-2c942f36210288a476144c7c4751674866975d58575a608fdcca1ff218566764">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schema.ts</strong><dd><code>Update translationsCache schema and index for sourceLanguage</code></dd></summary>
<hr>

convex/schema.ts

<li>Adds <code>sourceLanguage</code> field to <code>translationsCache</code> table<br> <li> Updates index to include <code>sourceLanguage</code> in uniqueness constraint


</details>


  </td>
  <td><a href="https://github.com/Jokerman890/Polyglote-Translater-Beta-v1.0.0.1/pull/4/files#diff-00e6e27e65e72a0fd4a73f6942f41e1cf3f476a59f263513f3f47fdf801a0eb1">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>